### PR TITLE
adding support for sundials version 2.7.0, not backward compatibile

### DIFF
--- a/src/arkode/arkode_ml.c
+++ b/src/arkode/arkode_ml.c
@@ -1600,40 +1600,50 @@ CAMLprim value c_arkode_resize(value varkode_mem,
 CAMLprim value c_arkode_get_current_butcher_tables(value varkode_mem)
 {
     CAMLparam1(varkode_mem);
-    CAMLlocal4(rkm, vc, vb, vb2);
-    CAMLlocal3(r, ai, ae);
+    CAMLlocal3(rkm, ci, ce);
+    CAMLlocal4(bi, be, b2i, b2e);
+    CAMLlocal3(r, Ai, Ae);
 
     int flag;
     int s;
     int q;
     int p;
 
-    ai  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX * ARK_S_MAX);
-    ae  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX * ARK_S_MAX);
-    vc  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
-    vb  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
-    vb2 = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
+    Ai  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX * ARK_S_MAX);
+    Ae  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX * ARK_S_MAX);
+    ci  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
+    ce  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
+    bi  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
+    be  = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
+    b2i = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
+    b2e = caml_ba_alloc_dims (BIGARRAY_FLOAT, 1, NULL, ARK_S_MAX);
 
     flag = ARKodeGetCurrentButcherTables(ARKODE_MEM_FROM_ML(varkode_mem),
 					 &s, &q, &p,
-					 REAL_ARRAY(ai),
-					 REAL_ARRAY(ae),
-					 REAL_ARRAY(vc),
-					 REAL_ARRAY(vb),
-					 REAL_ARRAY(vb2));
+					 REAL_ARRAY(Ai),
+					 REAL_ARRAY(Ae),
+					 REAL_ARRAY(ci),
+					 REAL_ARRAY(ce),
+					 REAL_ARRAY(bi),
+					 REAL_ARRAY(be),
+					 REAL_ARRAY(b2i),
+					 REAL_ARRAY(b2e));
     CHECK_FLAG("ARKodeGetCurrentButcherTables", flag);
 
     rkm = caml_alloc_tuple(RECORD_ARKODE_RK_METHOD_SIZE);
     Store_field(rkm, RECORD_ARKODE_RK_METHOD_STAGES, Val_int(s));
     Store_field(rkm, RECORD_ARKODE_RK_METHOD_GLOBAL_ORDER, Val_int(q));
     Store_field(rkm, RECORD_ARKODE_RK_METHOD_GLOBAL_EMBEDDED_ORDER,Val_int(p));
-    Store_field(rkm, RECORD_ARKODE_RK_METHOD_STAGE_TIMES, vc);
-    Store_field(rkm, RECORD_ARKODE_RK_METHOD_COEFFICIENTS, vb);
-    Store_field(rkm, RECORD_ARKODE_RK_METHOD_BEMBED, vb2);
+    Store_field(rkm, RECORD_ARKODE_RK_METHOD_STAGE_TIMES, ci);
+    Store_field(rkm, RECORD_ARKODE_RK_METHOD_STAGE_TIMES, ce);
+    Store_field(rkm, RECORD_ARKODE_RK_METHOD_COEFFICIENTS, bi);
+    Store_field(rkm, RECORD_ARKODE_RK_METHOD_COEFFICIENTS, be);
+    Store_field(rkm, RECORD_ARKODE_RK_METHOD_BEMBED, b2i);
+    Store_field(rkm, RECORD_ARKODE_RK_METHOD_BEMBED, b2e);
 
     r = caml_alloc_tuple(3);
-    Store_field(r, 0, ai);
-    Store_field(r, 1, ae);
+    Store_field(r, 0, Ai);
+    Store_field(r, 1, Ae);
     Store_field(r, 2, rkm);
 
     CAMLreturn(r);
@@ -1688,9 +1698,12 @@ CAMLprim value c_arkode_set_ark_tables(value varkode_mem,
 	    Int_val(Field(vrkm, RECORD_ARKODE_RK_METHOD_GLOBAL_ORDER)),
 	    Int_val(Field(vrkm, RECORD_ARKODE_RK_METHOD_GLOBAL_EMBEDDED_ORDER)),
 	    REAL_ARRAY(Field(vrkm, RECORD_ARKODE_RK_METHOD_STAGE_TIMES)),
+	    REAL_ARRAY(Field(vrkm, RECORD_ARKODE_RK_METHOD_STAGE_TIMES)),
 	    REAL_ARRAY(vai),
 	    REAL_ARRAY(vae),
 	    REAL_ARRAY(Field(vrkm, RECORD_ARKODE_RK_METHOD_COEFFICIENTS)),
+	    REAL_ARRAY(Field(vrkm, RECORD_ARKODE_RK_METHOD_COEFFICIENTS)),
+	    REAL_ARRAY(Field(vrkm, RECORD_ARKODE_RK_METHOD_BEMBED)),
 	    REAL_ARRAY(Field(vrkm, RECORD_ARKODE_RK_METHOD_BEMBED)));
     CHECK_FLAG("ARKodeSetARKTables", flag);
 

--- a/src/lsolvers/sls_ml.c
+++ b/src/lsolvers/sls_ml.c
@@ -33,7 +33,7 @@
 
 static void finalize_slsmat(value va)
 {
-    DestroySparseMat(SLSMAT(va));
+    SparseDestroyMat(SLSMAT(va));
 }
 
 CAMLprim value c_sls_sparse_wrap(SlsMat a, int finalize)
@@ -106,7 +106,7 @@ CAMLprim value c_sparsematrix_new_sparse_mat(value vm, value vn, value vnnz)
     int n = Int_val(vn);
     int nnz = Int_val(vnnz);
 
-    SlsMat a = NewSparseMat(m, n, nnz);
+    SlsMat a = SparseNewMat(m, n, nnz, 0);
     if (a == NULL)
 	caml_raise_out_of_memory();
 
@@ -130,7 +130,7 @@ CAMLprim value c_sparsematrix_size(value va)
 CAMLprim value c_sparsematrix_print_mat(value va)
 {
     CAMLparam1(va);
-    PrintSparseMat(SLSMAT(va));
+    SparsePrintMat(SLSMAT(va), stdout);
     fflush(stdout);
     CAMLreturn (Val_unit);
 }
@@ -138,7 +138,7 @@ CAMLprim value c_sparsematrix_print_mat(value va)
 CAMLprim value c_sparsematrix_set_to_zero(value va)
 {
     CAMLparam1(va);
-    SlsSetToZero(SLSMAT(va));
+    SparseSetMatToZero(SLSMAT(va));
     CAMLreturn (Val_unit);
 }
 
@@ -148,7 +148,7 @@ CAMLprim value c_sparsematrix_convert_dls(value va)
     CAMLlocal1(vr);
 
     DlsMat da = DLSMAT(va);
-    SlsMat ma = SlsConvertDls(da);
+    SlsMat ma = SparseFromDenseMat(da, 0);
 
     CAMLreturn(c_sls_sparse_wrap(ma, 1));
 }
@@ -157,7 +157,7 @@ CAMLprim value c_sparsematrix_add_identity(value vma)
 {
     CAMLparam1(vma);
 
-    AddIdentitySparseMat(SLSMAT(Field(vma, RECORD_SLS_SPARSEMATRIX_SLSMAT)));
+    SparseAddIdentityMat(SLSMAT(Field(vma, RECORD_SLS_SPARSEMATRIX_SLSMAT)));
     c_sparsematrix_realloc(vma, Val_int(0));
 
     CAMLreturn (Val_unit);
@@ -167,7 +167,7 @@ CAMLprim value c_sparsematrix_copy(value va, value vmb)
 {
     CAMLparam2(va, vmb);
 
-    CopySparseMat(SLSMAT(va),
+    SparseCopyMat(SLSMAT(va),
 		  SLSMAT(Field(vmb, RECORD_SLS_SPARSEMATRIX_SLSMAT)));
     c_sparsematrix_realloc(vmb, Val_int(0));
 
@@ -177,7 +177,7 @@ CAMLprim value c_sparsematrix_copy(value va, value vmb)
 CAMLprim value c_sparsematrix_scale(value vc, value va)
 {
     CAMLparam2(vc, va);
-    ScaleSparseMat(Double_val(vc), SLSMAT(va));
+    SparseScaleMat(Double_val(vc), SLSMAT(va));
     CAMLreturn (Val_unit);
 }
 
@@ -185,7 +185,7 @@ CAMLprim value c_sparsematrix_add(value vma, value vb)
 {
     CAMLparam2(vma, vb);
 
-    SlsAddMat(SLSMAT(Field(vma, RECORD_SLS_SPARSEMATRIX_SLSMAT)), SLSMAT(vb));
+    SparseAddMat(SLSMAT(Field(vma, RECORD_SLS_SPARSEMATRIX_SLSMAT)), SLSMAT(vb));
     c_sparsematrix_realloc(vma, Val_int(0));
 
     CAMLreturn (Val_unit);
@@ -204,7 +204,7 @@ CAMLprim value c_sparsematrix_matvec(value va, value vx, value vy)
 	caml_invalid_argument("SparseMatrix.matvec: y has wrong size.");
 #endif
 
-    SlsMatvec(a, REAL_ARRAY(vx), REAL_ARRAY(vy));
+    SparseMatvec(a, REAL_ARRAY(vx), REAL_ARRAY(vy));
     /* assert (r == 0) */
 
     CAMLreturn (Val_unit);


### PR DESCRIPTION
quick and dirty, compiles fine (Ocaml 4.03), OS  X Sierra, with sundials 2.7.0_1 via brew poured from bottle on 2016-11-17. Would be nice to check it on the current examples of Zelus, I need a fork to the latter though to test. 