### PR TITLE
Uniform use of -no-alias-deps

### DIFF
--- a/config.in
+++ b/config.in
@@ -116,7 +116,7 @@ DOCDIR = @docdir@
 INSTALL_DOCS = @install_docs@
 
 OCAMLOPT ?= @ocamlopt@
-OCAMLOPTFLAGS += @ocamloptflags@
+OCAMLOPTFLAGS += -no-alias-deps @ocamloptflags@
 
 OCAMLDEP ?= @ocamldep@
 OCAMLDOC ?= @ocamldoc@


### PR DESCRIPTION
The current compilation scheme of sundialsml rely on the property that cmi generated with and without the `-no-alias-deps` option are equivalent. This is not a guaranteed property, and the compilation fails with the latest OCaml 4.12.0 beta.

This PR fixes this issue by using `-no-alias-deps` in both the bytecode and native mode.

The precise issue appears during the native compilation mode of `lsolvers/sundials_LinearSolver.ml`:

> ocamlopt.opt -bin-annot ... -c lsolvers/sundials_LinearSolver_impl.ml
ocamlopt.opt -bin-annot ...  -c lsolvers/sundials_LinearSolver.ml

In this sequence of command, the cmi for `sundials_LinearSolver_impl.ml` is accidentally recomputed without the `-no-alias-deps` option. This creates a conflict between the implementation of `sundials_LinearSolver.ml` and its interface : the implementation includes the no-`-no-alias-deps` variant of `sundials_LinearSolver_impl.cmi`  whereas the interface still links to the bytecode version compiled with `-no-alias-deps`.
 