### PR TITLE
WIP: Registering finalizers through Gc.finalise

### DIFF
--- a/src/arkode/arkode.ml
+++ b/src/arkode/arkode.ml
@@ -49,6 +49,13 @@ exception BadT
 
 exception VectorOpErr
 
+external finalize_mri_coupling : unit (*session*) -> unit = "finalize_mri_coupling"
+let _ = Callback.register "finalize_mri_coupling" finalize_mri_coupling
+external finalize_sundials_istepper : unit (*session*) -> unit = "finalize_sundials_istepper"
+let _ = Callback.register "finalize_sundials_istepper" finalize_sundials_istepper
+external finalize_istepper : unit (*session*) -> unit = "finalize_istepper"
+let _ = Callback.register "finalize_istepper" finalize_istepper
+
 module Common = struct (* {{{ *)
 
   include Arkode_impl.Global

--- a/src/arkode/arkode_ml.c
+++ b/src/arkode/arkode_ml.c
@@ -6992,8 +6992,9 @@ CAMLprim value sunml_arkode_mri_set_deduce_implicit_rhs(value varkode_mem,
 #define ML_MRI_COUPLING(v) (*(MRIStepCoupling *)Data_custom_val(v))
 
 #if 540 <= SUNDIALS_LIB_VERSION
-static void finalize_mri_coupling(value vcptr)
+CAMLprim value finalize_mri_coupling(value vcptr)
 {
+  CAMLparam1(vcptr);
 
     MRIStepCoupling MRIC = ML_MRI_COUPLING(vcptr);
     int i;
@@ -7019,6 +7020,7 @@ static void finalize_mri_coupling(value vcptr)
 	}
 	free(MRIC);
     }
+  CAMLreturn(Val_unit);
 }
 #endif
 
@@ -7109,7 +7111,8 @@ CAMLprim value sunml_arkode_mri_coupling_make(
     MRIC->c = REAL_ARRAY(vc);
 
     // Create a cptr wrapper
-    vcptr = caml_alloc_final(1, &finalize_mri_coupling, 1, 20);
+    vcptr = caml_alloc_final(1, custom_finalize_default, 1, 20);
+    caml_callback2(*caml_named_value("mlfinalise_register"), *caml_named_value("finalize_mri_coupling"), vcptr);
     ML_MRI_COUPLING(vcptr) = MRIC;
 #else
     caml_raise_constant(SUNDIALS_EXN(NotImplementedBySundialsVersion));
@@ -7168,7 +7171,8 @@ static value sunml_arkode_mri_coupling_wrap(MRIStepCoupling MRIC)
 	Store_some(vog, vwg);
     }
 
-    vcptr = caml_alloc_final(1, &finalize_mri_coupling, 1, 20);
+    vcptr = caml_alloc_final(1, custom_finalize_default, 1, 20);
+    caml_callback2(*caml_named_value("mlfinalise_register"), *caml_named_value("finalize_mri_coupling"), vcptr);
     ML_MRI_COUPLING(vcptr) = MRIC;
 
     // create the record
@@ -7665,8 +7669,9 @@ CAMLprim value sunml_arkode_mri_set_stage_predict_fn(value varkode_mem,
  */
 
 #if 580 <= SUNDIALS_LIB_VERSION
-static void finalize_istepper(value vistepper_cptr)
+CAMLprim value finalize_istepper(value vistepper_cptr)
 {
+  CAMLparam1(vistepper_cptr);
     MRIStepInnerStepper stepper = ISTEPPER(vistepper_cptr);
 
     value *pvcallbacks = NULL;
@@ -7674,13 +7679,16 @@ static void finalize_istepper(value vistepper_cptr)
     if (pvcallbacks != NULL) sunml_sundials_free_value(pvcallbacks);
 
     MRIStepInnerStepper_Free(&stepper);
+  CAMLreturn(Val_unit);
 }
 
 #if 600 <= SUNDIALS_LIB_VERSION
-static void finalize_sundials_istepper(value vistepper_cptr)
+CAMLprim value finalize_sundials_istepper(value vistepper_cptr)
 {
+  CAMLparam1(vistepper_cptr);
     MRIStepInnerStepper stepper = ISTEPPER(vistepper_cptr);
     MRIStepInnerStepper_Free(&stepper);
+  CAMLreturn(Val_unit);
 }
 #endif
 
@@ -7790,7 +7798,8 @@ CAMLprim value sunml_arkode_mri_istepper_from_arkstep(value varkode_mem)
 					    &stepper);
     CHECK_FLAG("ARKStepCreateMRIStepInnerStepper", flag);
 
-    r = caml_alloc_final(1, &finalize_sundials_istepper, 0, 1);
+    r = caml_alloc_final(1, custom_finalize_default, 0, 1);
+    caml_callback2(*caml_named_value("mlfinalise_register"), *caml_named_value("finalize_sundials_istepper"), r);
     ISTEPPER(r) = stepper;
 #else
     r = Val_unit;
@@ -7846,7 +7855,8 @@ CAMLprim value sunml_arkode_mri_istepper_create(value vcallbacks,
 	sunml_arkode_check_flag("MRIStepInnerStepper_SetContent", flag, NULL);
     }
 
-    vistepper = caml_alloc_final(1, &finalize_istepper, 0, 1);
+    vistepper = caml_alloc_final(1, custom_finalize_default, 0, 1);
+    caml_callback2(*caml_named_value("mlfinalise_register"), *caml_named_value("finalize_istepper"), vistepper);
     ISTEPPER(vistepper) = stepper;
 #endif
     CAMLreturn(vistepper);

--- a/src/lsolvers/sundials_LinearSolver.ml
+++ b/src/lsolvers/sundials_LinearSolver.ml
@@ -35,6 +35,11 @@ exception IllegalPrecType
 exception InternalFailure of (string * int)
 exception ZeroInDiagonal of int
 
+external finalize_custom_lsolver : unit (*linearsolver*) -> unit = "finalize_custom_lsolver"
+let _ = Callback.register "finalize_custom_lsolver" finalize_custom_lsolver
+external finalize_lsolver : unit (*linearsolver*) -> unit = "finalize_lsolver"
+let _ = Callback.register "finalize_lsolver" finalize_lsolver
+
 type ('mat, 'data, 'kind, 'tag) t = ('mat, 'data, 'kind, 'tag) linear_solver
 
 (** Alias for linear solvers that are restricted to serial nvectors. *)

--- a/src/lsolvers/sundials_Matrix.ml
+++ b/src/lsolvers/sundials_Matrix.ml
@@ -48,6 +48,17 @@ type ('m, 'd) matrix_ops = {
   m_space        : 'm -> int * int;
 }
 
+external finalize_mat_content_dense : unit (*session*) -> unit = "finalize_mat_content_dense"
+let _ = Callback.register "finalize_mat_content_dense" finalize_mat_content_dense
+external finalize_mat_content_band : unit (*session*) -> unit = "finalize_mat_content_band"
+let _ = Callback.register "finalize_mat_content_band" finalize_mat_content_band
+external finalize_mat_content_sparse : unit (*session*) -> unit = "finalize_mat_content_sparse"
+let _ = Callback.register "finalize_mat_content_sparse" finalize_mat_content_sparse
+external finalize_caml_smat : unit (*session*) -> unit = "finalize_caml_smat"
+let _ = Callback.register "finalize_caml_smat" finalize_caml_smat
+external finalize_caml_custom_smat : unit (*session*) -> unit = "finalize_caml_custom_smat"
+let _ = Callback.register "finalize_caml_custom_smat" finalize_caml_custom_smat
+
 module Dense = struct (* {{{ *)
 
   type data = RealArray2.data

--- a/src/lsolvers/sundials_NonlinearSolver.ml
+++ b/src/lsolvers/sundials_NonlinearSolver.ml
@@ -119,6 +119,9 @@ external c_set_print_level_newton : ('d, 'k, 's, 'v) cptr -> int -> unit
 
 (* - - - OCaml invoking init/setup/solve - - - *)
 
+external finalize_nls : unit (*session*) -> unit = "finalize_nls"
+let _ = Callback.register "finalize_nls" finalize_nls
+
 let uw = Nvector.unwrap
 
 let init (type v) ({ rawptr; solver } : ('d, 'k, 's, v) t) =

--- a/src/lsolvers/sundials_nonlinearsolver_ml.c
+++ b/src/lsolvers/sundials_nonlinearsolver_ml.c
@@ -1058,11 +1058,13 @@ CAMLprim void sunml_nlsolver_set_print_level_fixedpoint(value vnls, value vlevel
 }
 
 #if 400 <= SUNDIALS_LIB_VERSION
-static void finalize_nls(value vnls)
+CAMLprim value finalize_nls(value vnls)
 {
+  CAMLparam1(vnls);
     SUNNonlinearSolver nls = NLSOLVER_VAL(vnls);
     caml_remove_generational_global_root(&NLS_CALLBACKS(nls));
     SUNNonlinSolFree(nls);
+    CAMLreturn(Val_unit);
 }
 #endif
 
@@ -1496,7 +1498,8 @@ static value rewrap_nlsolver(SUNNonlinearSolver nls0, value vcallbacks)
     }
 
     // Setup the OCaml-side
-    vr = caml_alloc_final(1, &finalize_nls, 1, 20);
+    vr = caml_alloc_final(1, custom_finalize_default, 1, 20);
+    caml_callback2(*caml_named_value("mlfinalise_register"), *caml_named_value("finalize_nls,"), vr);
     NLSOLVER_VAL(vr) = nls;
 
     CAMLreturn (vr);
@@ -2154,7 +2157,8 @@ static CAMLprim value custom_make(int sens, value vcallbacks, value vweakops,
     NLS_CALLBACKS(nls) = vcallbacks;
     caml_register_generational_global_root(&NLS_CALLBACKS(nls));
 
-    vnls = caml_alloc_final(1, &finalize_nls, 1, 20);
+    vnls = caml_alloc_final(1, custom_finalize_default, 1, 20);
+    caml_callback2(*caml_named_value("mlfinalise_register"), *caml_named_value("finalize_nls,"), vnls);
     NLSOLVER_VAL(vnls) = nls;
 
     CAMLreturn (vnls);

--- a/src/nvectors/nvector.ml
+++ b/src/nvectors/nvector.ml
@@ -24,6 +24,8 @@ type ('data, 'kind) nvector =
 and ('data, 'kind) t = ('data, 'kind) nvector
 [@@@ocaml.warning "+37"]
 
+let _ = Callback.register "mlfinalise_register" Gc.finalise
+
 type 'k serial = (Sundials.RealArray.t, [>`Serial] as 'k) t
 
 let unwrap (NV { payload; _ }) = payload

--- a/src/nvectors/nvector_custom.ml
+++ b/src/nvectors/nvector_custom.ml
@@ -116,6 +116,9 @@ external c_make_wrap :
       -> 'a t
     = "sunml_nvec_wrap_custom"
 
+external finalize_custom_caml_nvec : unit (*cnvec*) -> unit = "finalize_custom_caml_nvec"
+let _ = Callback.register "finalize_custom_caml_nvec" finalize_custom_caml_nvec
+
 let do_enable f nv v =
   match v with
   | None -> ()

--- a/src/nvectors/nvector_many.ml
+++ b/src/nvectors/nvector_many.ml
@@ -32,6 +32,9 @@ external c_wrap
 
 let unwrap = Nvector.unwrap
 
+external finalize_caml_nvec_many : unit (*cnvec*) -> unit = "finalize_caml_nvec_many"
+let _ = Callback.register "finalize_caml_nvec_many" finalize_caml_nvec_many
+
 let rec wrap_withlen ctx ((nvs, _) as payload) =
   let check nv' =
     let nvs', _ = unwrap nv' in

--- a/src/nvectors/nvector_many_ml.c
+++ b/src/nvectors/nvector_many_ml.c
@@ -73,9 +73,11 @@ static void free_cnvec_many(N_Vector nv)
     free(nv);
 }
 
-static void finalize_caml_nvec_many (value vnv)
+CAMLprim value finalize_caml_nvec_many (value vnv)
 {
+    CAMLparam1(vnv);
     free_cnvec_many(NVEC_CVAL (vnv));
+    CAMLreturn(Val_unit);
 }
 
 /* Creation from Sundials/C.  */
@@ -292,7 +294,7 @@ static value do_wrap(value payload,
     /* Create vector */
     nv = sunml_alloc_cnvec(sizeof *content, payload);
     if (nv == NULL) caml_raise_out_of_memory();
-    vnv_cptr = sunml_alloc_caml_nvec(nv, finalize_caml_nvec_many);
+    vnv_cptr = sunml_alloc_caml_nvec(nv, *caml_named_value("finalize_caml_nvec_many"));
     ops = (N_Vector_Ops) nv->ops;
     content = (MVAPPEND(N_VectorContent)) nv->content;
 

--- a/src/nvectors/nvector_ml.h
+++ b/src/nvectors/nvector_ml.h
@@ -254,7 +254,7 @@ enum nv_index {
 // Internal functions
 N_Vector sunml_alloc_cnvec(size_t content_size, value backlink);
 void sunml_clone_cnvec_ops(N_Vector dst, N_Vector src);
-CAMLprim value sunml_alloc_caml_nvec(N_Vector nv, void (*finalizer)(value));
+CAMLprim value sunml_alloc_caml_nvec(N_Vector nv, value finalizer);
 void sunml_free_cnvec(N_Vector nv);
 CAMLprim void sunml_finalize_caml_nvec(value vnv);
 

--- a/src/nvectors/nvector_serial.ml
+++ b/src/nvectors/nvector_serial.ml
@@ -31,6 +31,9 @@ external c_enablelinearcombinationvectorarray_serial : ('d, 'k) Nvector.t -> boo
 
 let unwrap = Nvector.unwrap
 
+external sunml_finalize_caml_nvec : unit (*cnvec*) -> unit = "sunml_finalize_caml_nvec"
+let _ = Callback.register "sunml_finalize_caml_nvec" sunml_finalize_caml_nvec
+
 external c_wrap : RealArray.t -> (t -> bool) -> (t -> t) -> Context.t -> t
   = "sunml_nvec_wrap_serial"
 

--- a/src/sundials/sundials.ml
+++ b/src/sundials/sundials.ml
@@ -112,6 +112,17 @@ module Logger = struct
 
 end
 
+external finalize_context : unit (*session*) -> unit = "finalize_context"
+let _ = Callback.register "finalize_context" finalize_context
+external finalize_cfile : unit (*session*) -> unit = "finalize_cfile"
+let _ = Callback.register "finalize_cfile" finalize_cfile
+(*
+external finalize_profiler : unit (*session*) -> unit = "finalize_profiler"
+let _ = Callback.register "finalize_profiler" finalize_profiler
+external finalize_logger : unit (*session*) -> unit = "finalize_logger"
+let _ = Callback.register "finalize_logger" finalize_logger
+*)
+
 module Context = struct
   type t = Sundials_impl.Context.t
   exception ExternalProfilerInUse = Sundials_impl.Context.ExternalProfilerInUse

--- a/src/sundials/sundials_impl.ml
+++ b/src/sundials/sundials_impl.ml
@@ -67,6 +67,11 @@ end = struct
   type 'a vcptr
   type 'a vptr = 'a * 'a vcptr
 
+  external sunml_finalize_vptr : 'a vcptr -> unit = "sunml_finalize_vptr"
+  let _ = Callback.register "sunml_finalize_vptr" sunml_finalize_vptr
+  external finalize_session_pointer : unit (*session*) -> unit = "finalize_session_pointer"
+  let _ = Callback.register "finalize_session_pointer" finalize_session_pointer
+
   external make : 'a -> 'a vptr
     = "sunml_make_vptr"
 


### PR DESCRIPTION
Il y a deux finalizers qui n'existe pas dans ma configuration :
- `finalize_profiler`
- `finalize_logger`

Je sais pas si on peut faire du préprocessing OCaml comme actuellement fait pour c, mais une opération de se type pourrait être intéressante. Aussi, j'ignore pourquoi mais mon `make -C examples perf.opt.log GC_EACH_REP=1` échoue avec l'erreur la fin de log :
```
../../../examples/utils/perf -m cvsFoodWeb_ASAi_kry.reps 3 ./cvsFoodWeb_ASAi_kry.opt | tee cvsFoodWeb_ASAi_kry.opt.time
# NUM_REPS=2
2.36
2.38
Fatal error: exception Failure("Command NUM_REPS=2 time -f %e -o /run/user/1000/sundials-perf.3a4801.tmp ./cvsFoodWeb_ASAi_kry.opt exited with nonzero status 139")
../../../examples/utils/perf -m cvsFoodWeb_ASAi_kry.reps 3 ./cvsFoodWeb_ASAi_kry.sundials | tee cvsFoodWeb_ASAi_kry.sundials.time
# NUM_REPS=2
1.12
^Cmake[1]: *** Deleting file 'cvsFoodWeb_ASAi_kry.sundials.time'
make[1]: *** [../../examples.mk:480: cvsFoodWeb_ASAi_kry.sundials.time] Interrupt
make: [Makefile:92: cvodes/serial/perf.opt.log] Interrupt (ignored)
```
Certain tests passe, nottament un qui était bloquant avant

Il faut aussi faire du rangement sur où on déclare les finalizers