### PR TITLE
add config variable for time binary available

### DIFF
--- a/configure
+++ b/configure
@@ -1694,6 +1694,29 @@ else
     nvecopenmp_info='disabled'
 fi
 
+time_binary=
+time_info='not available'
+
+test_stem=__configure_test_file__time_gnu
+echo "sleep 0.1" > $test_stem.sh
+chmod +x $test_stem.sh
+if time -f "%U %S %e" ./$test_stem.sh >$test_stem.log 2>&1; then
+    time_binary='time'
+    time_info='GNU time (time -f)'
+else
+    if gtime -f "%U %S %e" ./$test_stem.sh >$test_stem.log 2>&1; then
+        time_binary='gtime'
+        time_info='GNU time (gtime -f)'
+    else
+        time_info='not available'
+        warning="${warning}\n\tNeither 'time -f' nor 'gtime -f' are available."
+        warning="${warning}\n\tPerformance tests will not be able to run."
+        warning="${warning}\n\tTo fix this on macOS, install GNU time with: brew install gnu-time"
+        time_binary='time'
+    fi
+fi
+${debug_configure} || rm -f ./$test_stem.*
+
 # Sundials examples directory
 if [ "x$EXAMPLESROOT" = x ]; then
     # Try to infer it from the include path.
@@ -1939,6 +1962,7 @@ cat ${LOG}
 	 s#@XO@#${XO}#;
 	 s#@XS@#${XS}#;
 	 s#@EXAMPLESROOT@#${EXAMPLESROOT}#;
+	 s#@time_binary@#${time_binary}#;
 	 s#@OCAMLBIN@#${OCAMLBIN}#;" config.in) > config
 
 printf "/* Automatically generated file - don't edit!  See configure.  */\\n"\
@@ -2037,6 +2061,11 @@ else
     echo "let safe = true"  >> src/sundials/sundials_configuration.ml
 fi
 
+# Add time_binary configuration
+
+echo "let time_binary = \"${time_binary}\"" >> src/sundials/sundials_configuration.ml
+
+
 # Generate sundials/sundials_Index.ml
 echo "(* Automatically generated file - don't edit!  See configure.  *)"\
     > src/sundials/sundials_Index.ml
@@ -2064,6 +2093,15 @@ else
     echo "(** Type of indexes into sparse matrices. *)" >> src/sundials/sundials_Index.mli
     echo "type index_elt = Bigarray.int32_elt" >> src/sundials/sundials_Index.mli
 fi
+
+# Show detailed debug information if requested
+${debug_configure} && (
+    echo ""
+    echo "Debug information:"
+    echo "  Time command detection: ${time_info}"
+    echo "  Time binary path: ${time_binary:-'not found'}"
+    echo ""
+)
 
 ${debug_configure} && (echo "#----${logfile}:"; cat ${logfile})
 

--- a/examples/utils/perf.ml
+++ b/examples/utils/perf.ml
@@ -1,3 +1,6 @@
+(* Configuration for time binary *)
+let time_binary = Sundials.Config.time_binary
+
 let synopsis =
   {|perf -r <min time> <command>
 
@@ -66,7 +69,7 @@ let init_stop_watch executable args =
   and with_time_command executable args =
     (* We get the output from time(1) via a named file because in some
        cases the test program may print to stderr.  *)
-    let args = Array.append [|"time"; "-f"; "%e"; "-o"; ""; executable|] args
+    let args = Array.append [|time_binary; "-f"; "%e"; "-o"; ""; executable|] args
     and tmp_index = 4 (* the index after the "-o" *)
     in
     let with_temp_file f =
@@ -81,16 +84,17 @@ let init_stop_watch executable args =
       with_temp_file (fun tmpfile ->
         args.(tmp_index) <- tmpfile;
         env.(0) <- Printf.sprintf "NUM_REPS=%d" num_reps;
-        spawn_wait "time" args dev_null dev_null Unix.stderr;
+        spawn_wait time_binary args dev_null dev_null Unix.stderr;
         Scanf.bscanf (Scanf.Scanning.from_file tmpfile) "%f\n" (fun f -> f)
       )
   in
+
   try ignore (with_time_command "true" [||] 1);
     with_time_command executable args
   with _ ->
     prerr_string
       ("Warning: can't find time(1) that accepts -f and -o, measuring time\n" ^
-       "with OCaml.  This may be slightly less accurate than time(1).\n");
+        "with OCaml.  This may be slightly less accurate than time(1).\n");
     flush stderr;
     with_gettimeofday
 

--- a/src/sundials/sundials_Config.ml
+++ b/src/sundials/sundials_Config.ml
@@ -22,6 +22,7 @@ let superlumt_enabled = Sundials_configuration.superlumt_enabled
 let nvecpthreads_enabled = Sundials_configuration.nvecpthreads_enabled
 let nvecopenmp_enabled = Sundials_configuration.nvecopenmp_enabled
 let monitoring_enabled = Sundials_configuration.monitoring_enabled
+let time_binary = Sundials_configuration.time_binary
 
 (* Let C code know about some of the values in this module, and obtain
    a few parameters from the C side.  *)

--- a/src/sundials/sundials_Config.mli
+++ b/src/sundials/sundials_Config.mli
@@ -48,6 +48,10 @@ val nvecpthreads_enabled : bool
 (** Indicates whether openmp-based nvectors are available. *)
 val nvecopenmp_enabled : bool
 
+(** The time binary available for performance measurements.
+    Returns [binary] if GNU time is available (either "time" or "gtime") *)
+val time_binary : string
+
 (** The largest value representable as a real.
 
     @cvode <node5#s:types> Data Types *)


### PR DESCRIPTION
Add configurable time binary path for FreeBSD compatibility ([issue #18 ](https://github.com/inria-parkas/sundialsml/issues/18))